### PR TITLE
step.yml update

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -12,6 +12,8 @@ app:
 
 workflows:
   test:
+    before_run:
+    - audit-this-step
     steps:
     - script:
         inputs:

--- a/step.yml
+++ b/step.yml
@@ -29,35 +29,32 @@ toolkit:
   bash:
     entry_file: step.sh
 
-
 inputs:
   # All parameter we need to upload files to wetransfer
-  - wtu_mailsender: $wtu_mailsender
+  - wtu_mailsender:
     opts:
       title: Email of the sender
-      is_expand: true
       is_required: true
 
-  - wtu_mailreceiver: $wtu_mailreceiver
+  - wtu_mailreceiver:
     opts:
       title: One or more email separated by coma for receiver
       is_required: true
 
-  - wtu_filepath: $wtu_filepath
+  - wtu_filepath:
     opts:
       title: The path where are stored one or more files to upload
-      summary: You can specify a path or an environnement variable
       is_required: true
   
-  - wtu_message: $wtu_message
+  - wtu_message:
     opts:
       title: A little body for the mail
-      summary:
       is_required: true
 
   - wtu_language: "fr"
     opts:
       title: The language of the wetransfer receiver
+      is_required: true
       value_options:
         - "fr"
         - "en"
@@ -68,8 +65,7 @@ inputs:
       description: |
         Step prints additional debug information if this option
         is enabled
-      is_expand: true
-      is_required: false
+      is_required: true
       value_options:
         - "yes"
         - "no"


### PR DESCRIPTION
Changes:
- removed not predefined envs from input values

We add default value to a step input, if we can specify a correct default value for the input. This value may defined by direct value: `wtu_debug_mode: "no"` or may defined by preset env vars, like xcode-archive step's [project_path input](https://github.com/bitrise-io/steps-xcode-archive/blob/master/step.yml#L101), the `BITRISE_PROJECT_PATH` env is always defined for ios projects (if our scanner generated the initial config on the Add new app page).
In this step's case the removed values are not pre-set env vars, so when the user adds this step to a workflow, he will see that there are required inputs (like: `wtu_mailsender`), but the input values are already filled (like: `$wtu_mailsender`) and feels like the setup is done (even if these env are not yet defined).

- removed not defined input options
- removed step options with defult values
- run audit-this-step in test workflow