### PR TITLE
update bitrise.yml and step.sh

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -10,32 +10,44 @@ app:
   - BITRISE_STEP_GIT_CLONE_URL: https://github.com/kawaiseb/bitrise-step-wetransfer.git
   - MY_STEPLIB_REPO_FORK_GIT_URL: https://github.com/kawaiseb/bitrise-steplib
 
+  - WTU_MAILSENDER: "spousse@pagesjaunes.fr"
+  - WTU_MAILRECEIVER: "spousse@pagesjaunes.fr"
+  - WTU_FILEPATH: "/tmp/wetransfer"
+  - WTU_MESSAGE: "Test"
+  - WTU_DEBUG: "yes"
+
 workflows:
   test:
+    before_run:
+    - audit-this-step
     steps:
+    - change-workdir:
+        title: Switch working dir to _tmp dir
+        run_if: true
+        inputs:
+        - path: "$BITRISE_SOURCE_DIR/_tmp"
+        - is_create_path: true
     - script:
+        title: Prepare test file to send
         inputs:
         - content: |
             #!/bin/bash
-            WTU_DEBUG="yes"
-            WTU_MAILSENDER="spousse@pagesjaunes.fr"
-            WTU_MAILRECEIVER="spousse@pagesjaunes.fr"
-            WTU_FILEPATH="/tmp/wetransfer"
-            WTU_MESSAGE="Test"
-
             mkdir $WTU_FILEPATH
             echo "I love bitrise" > ${WTU_FILEPATH}/test.txt
-
-            npm install wetransfert --save
-            ./upload.js "${WTU_DEBUG}" "${WTU_MAILSENDER}" "${WTU_MAILRECEIVER}" "${WTU_FILEPATH}" "${WTU_MESSAGE}" "${WTU_LANGUAGE}"
-
-            #cleaning
-            rm -rf $WTU_FILEPATH
+    - path::./:
+        title: Step test
+        inputs:
+        - wtu_mailsender: $WTU_MAILSENDER
+        - wtu_mailreceiver: $WTU_MAILRECEIVER
+        - wtu_filepath: $WTU_FILEPATH
+        - wtu_message: $WTU_MESSAGE
+        - wtu_debug_mode: $WTU_DEBUG
     - script:
+        title: Remove test file
         inputs:
         - content: |
             #!/bin/bash
-            echo "***** End of the wetransfer step *****"
+            rm -rf $WTU_FILEPATH
 
   # ----------------------------------------------------------------
   # --- workflows to Share this step into a Step Library

--- a/step.sh
+++ b/step.sh
@@ -3,6 +3,6 @@ set -ex
 
 THIS_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-npm install -g wetransfert
+npm install wetransfert --save
 
 $THIS_SCRIPT_DIR/upload.js "${wtu_debug_mode}" "${wtu_mailsender}" "${wtu_mailreceiver}" "${wtu_filepath}" "${wtu_message}" "${wtu_language}"


### PR DESCRIPTION
bitrise.yml changes:

- Switch working dir step makes sure that your step does not depends on the current working directory
- Using `path::./:` you tells bitrise-cli to use the step in the current directory, so it will use the current local state of your step
- My previous suggestion about wetransfert installation was incorrect, sorry about that. wetransfert has to be installed by: `npm install wetransfert --save` to make the step able to use the wetransfert node module